### PR TITLE
Revert back to the good old days of Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone Repository (Latest)
         uses: actions/checkout@v3


### PR DESCRIPTION
Since 'ubuntu-latest' transitioned to 22.04 the builds are cursed for some people. It's a known issue being worked on by the Actions team, for now the solution is to manually specify 'ubuntu-20.04' for the environment. Hopefully that works, if not you can revert and bonk me on Discord.